### PR TITLE
Fix #17: network configuration for datapusher

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,8 @@ services:
       context: datapusher/
     ports:
       - "8800:8800"
+    extra_hosts:
+    - "ckan:192.168.65.2"
 
   db:
     container_name: db


### PR DESCRIPTION
So far the easiest solution to #17 I've found is to set the `ckan` host in the datapusher container and on the host machine. 

It doens't really matter what host name is used for the CKAN instance, but for the example I will use the default setting from `.env.example`, which uses `ckan` as the host name.

To make the CKAN container accessible from both the `datapusher` instance and  the host machine we need to add an entry in the hosts file for both locations.

This PR adds the following to the `datapusher` service in the compose file:
``` 
extra_hosts:
- "ckan:192.168.65.2"
```
What the user needs to do is add an entry to `/etc/hosts`:
```
127.0.0.1       ckan
```
Now we can access the CKAN instance in the browser at `http://ckan:5000`, and the `datapusher` service will be able to connect and post results as well.

I've used the IP `192.168.65.2` here as this resolves to the host machine in Docker for Mac, but I'm not sure if this is always consistent across versions and OS.

Let me know what you think of this solution. If this is good I can add some documentation. 