### PR TITLE
Fix sysadmin creation for ckan-2.8

### DIFF
--- a/2.8/ckan-base/setup/prerun.py
+++ b/2.8/ckan-base/setup/prerun.py
@@ -149,7 +149,7 @@ def create_sysadmin():
         command = ['paster', '--plugin=ckan', 'user', name, '-c', ckan_ini]
 
         out = subprocess.check_output(command)
-        if 'User: \nNone\n' not in out:
+        if 'User:None' not in re.sub(r'\s', '', out):
             print '[prerun] Sysadmin user exists, skipping creation'
             return
 


### PR DESCRIPTION
I think the current check doesn't work with e.g. my setup because of the whitespace:

```
paster --plugin=ckan user ckan_admin -c $CKAN_INI
2018-08-03 14:49:37,652 DEBUG [ckanext.harvest.model] Harvest tables defined in memory
2018-08-03 14:49:37,665 DEBUG [ckanext.harvest.model] Harvest tables already exist
2018-08-03 14:49:38,220 DEBUG [ckanext.harvest.model] Harvest tables already exist
User:
 None
```