### PR TITLE
fixed init order

### DIFF
--- a/ckan-base/setup/start_ckan.sh
+++ b/ckan-base/setup/start_ckan.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# Update the plugins setting in the ini file with the values defined in the env var
-echo "Loading the following plugins: $CKAN__PLUGINS"
-paster --plugin=ckan config-tool $CKAN_INI "ckan.plugins = $CKAN__PLUGINS"
-
 # Run the prerun script to init CKAN and create the default admin user
 python prerun.py
 


### PR DESCRIPTION
A custom plugin that implements [IConfigurable](https://docs.ckan.org/en/2.8/extensions/plugin-interfaces.html#ckan.plugins.interfaces.IConfigurable) might require the database when it is loaded, in particular when it is loaded by a paster command such as `paster db init`.

In the current code this leads to startup failure.

This PR solves the problem by moving the update of the list of plugins from `start_ckan.py` into a function in `prerun.py` where it is called **after** `init_db()`.