### PR TITLE
timezone issue

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ CKAN_PORT=5000
 CKAN_SYSADMIN_NAME=ckan_admin
 CKAN_SYSADMIN_PASSWORD=test1234
 CKAN_SYSADMIN_EMAIL=your_email@example.com
+TZ=UTC
 
 # Database connections (TODO: avoid duplication)
 CKAN_SQLALCHEMY_URL=postgresql://ckan:ckan@db/ckan

--- a/ckan-base/2.7/Dockerfile
+++ b/ckan-base/2.7/Dockerfile
@@ -16,7 +16,8 @@ ENV CKAN__PLUGINS image_view text_view recline_view datastore datapusher envvars
 WORKDIR ${APP_DIR}
 
 # Install necessary packages to run CKAN
-RUN apk add --no-cache git \
+RUN apk add --no-cache tzdata \
+        git \
         gettext \
         postgresql-client \
         python \

--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -16,7 +16,8 @@ ENV CKAN__PLUGINS image_view text_view recline_view datastore datapusher envvars
 WORKDIR ${APP_DIR}
 
 # Install necessary packages to run CKAN
-RUN apk add --no-cache git \
+RUN apk add --no-cache tzdata \
+        git \
         gettext \
         postgresql-client \
         python \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -2,6 +2,10 @@ FROM openknowledge/ckan-base:2.8
 
 MAINTAINER Your Name Here <you@example.com>
 
+# Set timezone
+ARG TZ
+RUN echo $TZ > /etc/timezone
+RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
 
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -2,6 +2,11 @@ FROM openknowledge/ckan-dev:2.8
 
 MAINTAINER Your Name Here <you@example.com>
 
+# Set timezone
+ARG TZ
+RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
+RUN echo $TZ > /etc/timezone
+
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)
 # For instance:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ckan/
       dockerfile: Dockerfile.dev
+      args:
+        - TZ=${TZ}
     env_file:
       - .env
     links:
@@ -17,6 +19,7 @@ services:
     volumes:
       - ./src:/srv/app/src_extensions
       - ckan_storage:/var/lib/ckan
+    
 
   datapusher:
     container_name: datapusher

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     container_name: ckan
     build:
       context: ckan/
+      dockerfile: Dockerfile
+      args:
+        - TZ=${TZ}
     env_file:
       - .env
     links:


### PR DESCRIPTION
Various user actions result in server crash (in the "production" container) with the following log:

```
ckan          | File '/usr/lib/python2.7/site-packages/tzlocal/unix.py', line 123 in get_localzone
ckan          |   _cache_tz = _get_localzone()
ckan          | File '/usr/lib/python2.7/site-packages/tzlocal/unix.py', line 117 in _get_localzone
ckan          |   raise pytz.UnknownTimeZoneError('Can not find any timezone configuration')
ckan          | UnknownTimeZoneError: 'Can not find any timezone configuration'
```
This is because no timezone is set in the alpine image.
This PR fixes that by

1. Installing timezone database in ckan-base.
2. Adding a variable `TZ` to `.env.example` (default=UTZ).
3. Setting the timezone in images ckan and ckan-dev.