### PR TITLE
postgres fails to init db

### DIFF
--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -12,3 +12,4 @@ ARG DATASTORE_READONLY_PASSWORD
 
 # Include extra setup scripts (eg datastore)
 ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
+RUN chown -R postgres:postgres /docker-entrypoint-initdb.d


### PR DESCRIPTION
this adresses the issue that postgres lacks permissions to read sql files in `/docker-entrypoint-initdb.d` and db initialization fails