### PR TITLE
envvars to beginning of plugin list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,7 @@ CKAN_SMTP_MAIL_FROM=ckan@localhost
 
 # Extensions
 
-CKAN__PLUGINS=image_view text_view recline_view datastore datapusher envvars
+CKAN__PLUGINS=envvars image_view text_view recline_view datastore datapusher
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
Some extensions require config variables at load time, e.g. [ckanext-scheming](https://github.com/ckan/ckanext-scheming). If these variables are supplied via [ckanext-envvars](https://github.com/okfn/ckanext-envvars), envvars has to be loaded before the respective plugins. If that is not the case, ckanext-scheming for example will not load its schemata. 