### PR TITLE
removed py-geos@testing from ckan-base Dockerfile

### DIFF
--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -58,7 +58,7 @@ RUN apk add --no-cache tzdata \
     rm -rf ${SRC_DIR}/get-pip.py
 
 RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-    apk add --update --no-cache geos@testing geos-dev@testing py-geos@testing
+    apk add --update --no-cache geos@testing geos-dev@testing
 
 COPY setup/supervisord.conf /etc
 


### PR DESCRIPTION
Build of `ckan-base` fails because `py-geos` is not an [Alpine package](https://pkgs.alpinelinux.org/packages) anymore. Really, I searched extensively. [Google cache](https://webcache.googleusercontent.com/search?q=cache:dLIhMtPpta4J:https://pkgs.alpinelinux.org/package/edge/testing/x86/py-geos+&cd=8&hl=de&ct=clnk&gl=ch&client=firefox-b-d) tells me that it still was on Juli 5th.

Since this package contained "geos Python bindings", and geos Python bindings are provided by [Shapely](https://pypi.org/project/Shapely/), chances are it is not necessary. Container builds and seems to run OK with [ckanext-spatial](https://github.com/ckan/ckanext-spatial) enabled.