### PR TITLE
Fix typo in datapusher Dockerfile

### DIFF
--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -36,4 +36,4 @@ RUN apk add --no-cache python \
 COPY setup ${APP_DIR}
 
 EXPOSE 8800
-5CMD ["gunicorn", "--bind=0.0.0.0:8800", "--log-file=-", "wsgi"]
+CMD ["gunicorn", "--bind=0.0.0.0:8800", "--log-file=-", "wsgi"]


### PR DESCRIPTION
Fix a parse error when building: `ERROR: Dockerfile parse error line 39: unknown instruction: 5CMD`