### PR TITLE
Allow to optionally choose PostGIS enabled image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,10 @@
 POSTGRES_PASSWORD=ckan
 DATASTORE_READONLY_PASSWORD=datastore
 
+# Choose DB base image: Postgis enabled or not
+# DB_BASE_IMAGE=mdillon/postgis:latest
+DB_BASE_IMAGE=postgres:9.6-alpine
+
 # Basic
 CKAN_SITE_ID=default
 CKAN_SITE_URL=http://ckan:5000

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
         - TZ=${TZ}
     env_file:
       - .env
-    links:
+    depends_on:
       - db
       - solr
       - redis
@@ -34,6 +34,8 @@ services:
       - .env
     build:
       context: postgresql/
+      args:
+        - BASE_IMAGE=${DB_BASE_IMAGE}
     volumes:
       - pg_data:/var/lib/postgresql/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         - TZ=${TZ}
     env_file:
       - .env
-    links:
+    depends_on:
       - db
       - solr
       - redis
@@ -33,6 +33,7 @@ services:
     build:
       context: postgresql/
       args:
+        - BASE_IMAGE=${DB_BASE_IMAGE}
         - DATASTORE_READONLY_PASSWORD=${DATASTORE_READONLY_PASSWORD}
         - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     environment:

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -1,4 +1,5 @@
-FROM postgres:9.6-alpine
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 MAINTAINER Open Knowledge International
 
 # Allow connections; we don't map out any ports so only linked docker containers can connect


### PR DESCRIPTION
We need PostGIS for [ckanext-spatial](https://github.com/ckan/ckanext-spatial).
Also: replaced deprecated option `links`with `depends_on`in `docker-compose[.dev].yml`
