### PR TITLE
named ckan container for dev

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   ckan-dev:
+    container_name: ckan
     build:
       context: ckan/
       dockerfile: Dockerfile.dev


### PR DESCRIPTION
If no `container_name` is set for service `ckan-dev`, docker-compose names it according to the default container-naming schema. This results in datapusher being not able to call back to ckan and views of tabular data not working.
