### PR TITLE
fixed storagepath permissions

### DIFF
--- a/ckan-base/setup/prerun.py
+++ b/ckan-base/setup/prerun.py
@@ -96,6 +96,15 @@ def init_db():
         else:
             print e.output
             raise e
+    else:
+        storage_path = os.environ['CKAN_STORAGE_PATH']
+        try:
+            subprocess.check_output(['chown', '-R', 'ckan:ckan', storage_path],
+                                    stderr=subprocess.STDOUT)
+            print('[prerun] Changed permissions of {}').format(storage_path)
+        except Exception as e:
+            print(e)
+            raise e
 
 
 def init_datastore_db():


### PR DESCRIPTION
**Issue:** In production, create an organization and upload an image. There will be a server-error:
~~~
File '/usr/lib/python2.7/os.py', line 157 in makedirs  
ckan          |   mkdir(name, mode)                        
ckan          | OSError: [Errno 13] Permission denied: '/var/lib/ckan/storage/uploads' 
~~~

This is because `prerun.py`, in which ` init_db()` creates `/var/lib/ckan/storage`, runs as root. UWSGI in production however runs as `ckan`. That is also the reason this problem doesn't show in development.

This fix sets the permissions right.