### PR TITLE
Run the prerun.py script as ckan user

### DIFF
--- a/ckan-base/setup/start_ckan.sh
+++ b/ckan-base/setup/start_ckan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run the prerun script to init CKAN and create the default admin user
-python prerun.py
+sudo -u ckan -EH python prerun.py
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]

--- a/ckan-dev/setup/start_ckan_development.sh
+++ b/ckan-dev/setup/start_ckan_development.sh
@@ -59,7 +59,7 @@ paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "ckan.redis_url = $TEST_CKAN_REDIS_URL"
 
 # Run the prerun script to init CKAN and create the default admin user
-python prerun.py
+sudo -u ckan -EH python prerun.py
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]


### PR DESCRIPTION
This avoids the storage folder (/var/lib/ckan/storage) being owned by root

This is an alternative to #42 