### PR TITLE
Run db init as unprivileged ckan user

### DIFF
--- a/ckan-base/setup/prerun.py
+++ b/ckan-base/setup/prerun.py
@@ -81,7 +81,7 @@ def check_solr_connection(retry=None):
 
 def init_db():
 
-    db_command = ['paster', '--plugin=ckan', 'db',
+    db_command = ['sudo', '-u', 'ckan', 'paster', '--plugin=ckan', 'db',
                   'init', '-c', ckan_ini]
     print '[prerun] Initializing or upgrading db - start'
     try:


### PR DESCRIPTION
Make sure that any directory initialization is done with the ckan user so
on startup, ckan can write to these directories.

https://github.com/okfn/docker-ckan/issues/45