### PR TITLE
fix config key names in start_ckan_development.sh

### DIFF
--- a/ckan-dev/setup/start_ckan_development.sh
+++ b/ckan-dev/setup/start_ckan_development.sh
@@ -53,10 +53,10 @@ paster --plugin=ckan config-tool $CKAN_INI "ckan.plugins = $CKAN__PLUGINS"
 echo "Loading test settings into test-core.ini"
 paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
-    "ckan.datstore.write_url = $TEST_CKAN_DATASTORE_WRITE_URL" \
-    "ckan.datstore.read_url = $TEST_CKAN_DATASTORE_READ_URL" \
+    "ckan.datastore.write_url = $TEST_CKAN_DATASTORE_WRITE_URL" \
+    "ckan.datastore.read_url = $TEST_CKAN_DATASTORE_READ_URL" \
     "solr_url = $TEST_CKAN_SOLR_URL" \
-    "ckan.redis_url = $TEST_CKAN_REDIS_URL"
+    "ckan.redis.url = $TEST_CKAN_REDIS_URL"
 
 # Run the prerun script to init CKAN and create the default admin user
 sudo -u ckan -EH python prerun.py


### PR DESCRIPTION
Those config keys are wrong.

After starting in development mode and checking test-core.ini you can see that this leads to new config values with the wrong names being created instead of updating existing ones.