### PR TITLE
set uwsgi buffer size from 4096 to 32768

### DIFF
--- a/ckan-base/setup/start_ckan.sh
+++ b/ckan-base/setup/start_ckan.sh
@@ -17,7 +17,7 @@ then
 fi
 
 # Set the common uwsgi options
-UWSGI_OPTS="--plugins http,python,gevent --socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --paste-logger --lazy-apps --gevent 2000 -p 2 -L"
+UWSGI_OPTS="--plugins http,python,gevent --socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --paste-logger --lazy-apps --gevent 2000 -p 2 -L -b 32768"
 
 # Check whether http basic auth password protection is enabled and enable basicauth routing on uwsgi respecfully
 if [ $? -eq 0 ]


### PR DESCRIPTION
- ckan closes connection when request header size exceeds 4069 bytes
- this can easily happen when requests include long cookies (e.g. oauth tokens) etc.
- max setting for buffer size would be 65535 bytes, see https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

fixes #50 