### PR TITLE
prerun.py fails if `CKAN_DATASTORE_WRITE_URL` isn't defined

### DIFF
--- a/ckan-base/2.8/setup/prerun.py
+++ b/ckan-base/2.8/setup/prerun.py
@@ -34,6 +34,7 @@ def check_datastore_db_connection(retry=None):
     conn_str = os.environ.get('CKAN_DATASTORE_WRITE_URL')
     if not conn_str:
         print '[prerun] CKAN_DATASTORE_WRITE_URL not defined, not checking db'
+        return
     return check_db_connection(conn_str, retry)
 
 


### PR DESCRIPTION
prerun.py may fail with `TypeError` if CKAN_DATASTORE_WRITE_URL. This may not be the best fix; other possibilities include further error handling within the `check_db_connection` function.

Untested on 2.7 or 2.9.