### PR TITLE
pip 21 no longer support python 2.7

### DIFF
--- a/ckan-base/2.7/Dockerfile
+++ b/ckan-base/2.7/Dockerfile
@@ -45,8 +45,8 @@ RUN apk add --no-cache tzdata \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
-    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python ${SRC_DIR}/get-pip.py && \
+    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py && \
+    python ${SRC_DIR}/get-pip.py 'pip==20.3.3' && \
     pip install supervisor uwsgi && \
     mkdir /etc/supervisord.d && \
     #pip wheel --wheel-dir=/wheels uwsgi gevent && \

--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -46,7 +46,7 @@ RUN apk add --no-cache tzdata \
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
     curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py && \
-    python ${SRC_DIR}/get-pip.py && \
+    python ${SRC_DIR}/get-pip.py 'pip==20.3.3' && \
     pip install supervisor uwsgi && \
     mkdir /etc/supervisord.d && \
     #pip wheel --wheel-dir=/wheels uwsgi gevent && \

--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -45,7 +45,7 @@ RUN apk add --no-cache tzdata \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
-    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py && \
     python ${SRC_DIR}/get-pip.py && \
     pip install supervisor uwsgi && \
     mkdir /etc/supervisord.d && \

--- a/ckan-base/2.9/Dockerfile.py2
+++ b/ckan-base/2.9/Dockerfile.py2
@@ -45,8 +45,8 @@ RUN apk add --no-cache tzdata \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
-    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python2 ${SRC_DIR}/get-pip.py && \
+    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py && \
+    python2 ${SRC_DIR}/get-pip.py 'pip==20.3.3' && \
     pip2 install supervisor uwsgi && \
     mkdir /etc/supervisord.d && \
     #pip wheel --wheel-dir=/wheels uwsgi gevent && \


### PR DESCRIPTION
We need to pin pip version from CKAN 2.8 because pip no longer support python 2

https://pip.pypa.io/en/stable/
![image](https://user-images.githubusercontent.com/3237309/105706829-d134ea00-5ef0-11eb-9045-701334b41903.png)
