### PR TITLE
Add dependencies for compiling cryptography

### DIFF
--- a/ckan-base/2.9/Dockerfile
+++ b/ckan-base/2.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.13
 
 # Internals, you probably don't need to change these
 ENV APP_DIR=/srv/app
@@ -46,7 +46,11 @@ RUN apk add --no-cache tzdata \
         python3-dev \
         libxml2-dev \
         libxslt-dev \
-        linux-headers && \
+        linux-headers \
+        openssl-dev \
+        libffi-dev \
+        libffi-dev \
+        cargo && \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi


### PR DESCRIPTION
Fixes #66 

Similar to #65, but adds rust compiling tools to CKAN base image. Only fixes 2.9 with python3, if similar issue pops up in other images this needs to implemented in those as well.

Can be tested by building the image and running `pip install cryptography` within it.