### PR TITLE
2.9/py2: Prefer requirements-py2.txt to requirements.txt if both exist

### DIFF
--- a/ckan-dev/2.9/setup/start_ckan_development-py2.sh
+++ b/ckan-dev/2.9/setup/start_ckan_development-py2.sh
@@ -8,15 +8,18 @@ for i in $SRC_EXTENSIONS_DIR/*
 do
     if [ -d $i ];
     then
-
+        if [ -f $i/requirements-py2.txt ];
+        then
+            pip2 install -r $i/requirements-py2.txt
+            echo "Found requirements file in $i"
+        elif [ -f $i/requirements.txt ];
+        then
+            pip2 install -r $i/requirements.txt
+            echo "Found requirements file in $i"
+        fi
         if [ -f $i/pip-requirements.txt ];
         then
             pip2 install -r $i/pip-requirements.txt
-            echo "Found requirements file in $i"
-        fi
-        if [ -f $i/requirements.txt ];
-        then
-            pip2 install -r $i/requirements.txt
             echo "Found requirements file in $i"
         fi
         if [ -f $i/dev-requirements.txt ];


### PR DESCRIPTION
The current setup (where we always install from `requirements.txt`) means that if we try to run a ckan-dev container with a local CKAN install, we end up with a broken install because the python3 requirements are installed on python2. This switches it so that when we are running CKAN 2.9 on python2, we first look for `requirements-py2.txt` and fall back to `requirements.txt` if it does not exist.