### PR TITLE
Use the latest Solr 6.x

### DIFF
--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,4 +1,4 @@
-FROM solr:6.2-alpine
+FROM solr:6-slim
 MAINTAINER Open Knowledge
 
 # Enviroment


### PR DESCRIPTION
Use the latest 6.x release of Solr that includes fixes for known vulnerabilities.