### PR TITLE
Quote spaces in env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,7 @@ CKAN_SMTP_MAIL_FROM=ckan@localhost
 
 # Extensions
 
-CKAN__PLUGINS=envvars image_view text_view recline_view datastore datapusher
+CKAN__PLUGINS="envvars image_view text_view recline_view datastore datapusher"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379


### PR DESCRIPTION
https://github.com/okfn/docker-ckan/issues/86

Recent versions (2.1.1) of docker-compose error with "key cannot contain
a space". Any environment variable with spaces should be quoted.
