### PR TITLE
fix: fix criptography problem

### DIFF
--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.14
 
 MAINTAINER Open Knowledge Foundation
 
@@ -48,8 +48,7 @@ RUN apk del .build-deps && \
     rm -rf ${APP_DIR}/src
 
 # Create a local user and group to run the app
-RUN addgroup -g 92 -S www-data && \
-    adduser -u 92 -h /srv/app -H -D -S -G www-data www-data
+RUN adduser -u 92 -h /srv/app -H -D -S -G www-data www-data
 
 EXPOSE 8800
 


### PR DESCRIPTION
Error building the image from the repo

# Steps to reproduce
- Clone the repo
- Run `cp .env.example .env`
- Run `docker-compose -f docker-compose.dev.yml up --build`

These steps end up giving this error
```
#0 37.97   writing manifest file 'src/cryptography.egg-info/SOURCES.txt'
#0 37.97   copying src/cryptography/py.typed -> build/lib.linux-x86_64-cpython-38/cryptography
#0 37.97   copying src/cryptography/hazmat/bindings/_openssl.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings
#0 37.97   creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
#0 37.97   copying src/cryptography/hazmat/bindings/_rust/__init__.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
#0 37.97   copying src/cryptography/hazmat/bindings/_rust/asn1.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
#0 37.97   copying src/cryptography/hazmat/bindings/_rust/ocsp.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
#0 37.97   copying src/cryptography/hazmat/bindings/_rust/x509.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
#0 37.97   running build_ext
#0 37.97   running build_rust
#0 37.97   /tmp/pip-build-env-4uabd3cr/overlay/lib/python3.8/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'cryptography.hazmat.bindings._rust' as data is deprecated, please list it in `packages`.
#0 37.97       !!
#0 37.97   
#0 37.97   
#0 37.97       ############################
#0 37.97       # Package would be ignored #
#0 37.97       ############################
#0 37.97       Python recognizes 'cryptography.hazmat.bindings._rust' as an importable package,
#0 37.97       but it is not listed in the `packages` configuration of setuptools.
#0 37.97   
#0 37.97       'cryptography.hazmat.bindings._rust' has been automatically added to the distribution only
#0 37.97       because it may contain data files, but this behavior is likely to change
#0 37.97       in future versions of setuptools (and therefore is considered deprecated).
#0 37.97   
#0 37.97       Please make sure that 'cryptography.hazmat.bindings._rust' is included as a package by using
#0 37.97       the `packages` configuration field or the proper discovery methods
#0 37.97       (for example by using `find_namespace_packages(...)`/`find_namespace:`
#0 37.97       instead of `find_packages(...)`/`find:`).
#0 37.97   
#0 37.97       You can read more about "package discovery" and "data files" on setuptools
#0 37.97       documentation page.
#0 37.97   
#0 37.97   
#0 37.97   !!
#0 37.97   
#0 37.97     check.warn(importable)
#0 37.97   
#0 37.97       =============================DEBUG ASSISTANCE=============================
#0 37.97       If you are seeing a compilation error please try the following steps to
#0 37.97       successfully install cryptography:
#0 37.97       1) Upgrade to the latest pip and try again. This will fix errors for most
#0 37.97          users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
#0 37.97       2) Read https://cryptography.io/en/latest/installation/ for specific
#0 37.97          instructions for your platform.
#0 37.97       3) Check our frequently asked questions for more information:
#0 37.97          https://cryptography.io/en/latest/faq/
#0 37.97       4) Ensure you have a recent Rust toolchain installed:
#0 37.97          https://cryptography.io/en/latest/installation/#rust
#0 37.97   
#0 37.97       Python: 3.8.10
#0 37.97       platform: Linux-5.15.62-1-lts-x86_64-with
#0 37.97       pip: n/a
#0 37.97       setuptools: 65.3.0
#0 37.97       setuptools_rust: 1.5.1
#0 37.97       rustc: 1.47.0
#0 37.97       =============================DEBUG ASSISTANCE=============================
#0 37.97   
#0 37.97   error: Rust 1.47.0 does not match extension requirement >=1.48.0
#0 37.97   ----------------------------------------
#0 37.97   ERROR: Failed building wheel for cryptography
#0 37.97   Building wheel for cffi (setup.py): started
#0 45.37   Building wheel for cffi (setup.py): finished with status 'done'
#0 45.37   Created wheel for cffi: filename=cffi-1.15.1-cp38-cp38-linux_x86_64.whl size=418787 sha256=fd2a1f086d3cd5407aaef97e37f18ad91a439b968fbe1e75656a60a4379f1c09
#0 45.37   Stored in directory: /tmp/pip-ephem-wheel-cache-ucnt0bqz/wheels/4f/6c/1c/87e97bb9c55afbf66881d37eed21c108b012c29105af6be450
#0 45.38   Building wheel for json-table-schema (setup.py): started
#0 46.17   Building wheel for json-table-schema (setup.py): finished with status 'done'
#0 46.17   Created wheel for json-table-schema: filename=json_table_schema-0.2.1-py3-none-any.whl size=2591 sha256=85c10dc628b1f7da0f43df8beba080863847889f8cb07430e690533ea6073456
#0 46.17   Stored in directory: /tmp/pip-ephem-wheel-cache-ucnt0bqz/wheels/d9/e6/16/b3856c1ab37827779514bdfaf97b28b27bbf0c2c2fd6cc87b3
#0 46.18   Building wheel for lxml (setup.py): started
#0 197.4   Building wheel for lxml (setup.py): still running...
#0 258.4   Building wheel for lxml (setup.py): still running...
#0 285.8   Building wheel for lxml (setup.py): finished with status 'done'
#0 285.8   Created wheel for lxml: filename=lxml-4.9.1-cp38-cp38-linux_x86_64.whl size=8553982 sha256=e7785f3da81e6b284b4ff40b5f2ef0665897f81b83b56d133baff4a47dbb2581
#0 285.8   Stored in directory: /tmp/pip-ephem-wheel-cache-ucnt0bqz/wheels/03/02/29/e73e6bd0b04b9ddb5e40fe507107c1e6e148bf8521a1964685
#0 285.8   Building wheel for MarkupSafe (setup.py): started
#0 287.1   Building wheel for MarkupSafe (setup.py): finished with status 'done'
#0 287.1   Created wheel for MarkupSafe: filename=MarkupSafe-2.1.1-cp38-cp38-linux_x86_64.whl size=25001 sha256=6f8d80ef4d760af50ea8877c965d298c477bb0bd1aa678b24fce90a07545b81b
#0 287.1   Stored in directory: /tmp/pip-ephem-wheel-cache-ucnt0bqz/wheels/1e/4f/44/880eea76caa456b86230bdca1a0903ccf0382cd780bdae90d0
#0 287.1   Building wheel for SQLAlchemy (setup.py): started
#0 288.9   Building wheel for SQLAlchemy (setup.py): finished with status 'done'
#0 288.9   Created wheel for SQLAlchemy: filename=SQLAlchemy-1.3.24-cp38-cp38-linux_x86_64.whl size=1253862 sha256=743eb14622d74094e7f91f20121511277166f8b50753ffbe60fb0e2277902df3
#0 288.9   Stored in directory: /tmp/pip-ephem-wheel-cache-ucnt0bqz/wheels/24/d2/fe/b05f62703bf7a666e348fe46c74a232c2cc8fbbe427f625f3b
#0 288.9 Successfully built ckanserviceprovider messytables cffi json-table-schema lxml MarkupSafe SQLAlchemy
#0 288.9 Failed to build cryptography
#0 288.9 ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
------
failed to solve: executor failed running [/bin/sh -c mkdir ${APP_DIR}/src && cd ${APP_DIR}/src &&     git clone -b ${GIT_BRANCH} --depth=1 --single-branch ${GIT_URL} &&     cd datapusher &&     python3 setup.py install &&     pip3 install --no-cache-dir -r requirements.txt]: exit code: 1

```

From what i can gather the problem is in the `datapusher` Dockerfile, the reason being that `alpine:3.13` only provides Rust up to version 1.47, while 1.48 is being required

Changing the datapusher docker file from 

```
FROM alpine:3.13

MAINTAINER Open Knowledge Foundation

ENV APP_DIR=/srv/app
...
```

To

```
FROM alpine:3.14

MAINTAINER Open Knowledge Foundation

ENV APP_DIR=/srv/app
...
```

Fixes the problem, but then we have this error

```
 > [docker-ckan-datapusher 6/6] RUN addgroup -g 92 -S www-data &&     adduser -u 92 -h /srv/app -H -D -S -G www-data www-data:
#0 0.555 addgroup: group 'www-data' in use
------
failed to solve: executor failed running [/bin/sh -c addgroup -g 92 -S www-data &&     adduser -u 92 -h /srv/app -H -D -S -G www-data www-data]: exit code: 1
```

It seems there is already a "www-data" user 

Changing this section of the Dockerfile from 

```
...
# Create a local user and group to run the app
RUN addgroup -g 92 -S www-data && \
    adduser -u 92 -h /srv/app -H -D -S -G www-data www-data
...
```

To

```
...
# Create a local user and group to run the app
RUN adduser -u 92 -h /srv/app -H -D -S -G www-data www-data
...
```

Solves the issue and it seems to make the docker images work.