### PR TITLE
Update datapusher version to the latest one (0.0.18) in its Dockerfile

### DIFF
--- a/datapusher/Dockerfile
+++ b/datapusher/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.13
 MAINTAINER Open Knowledge Foundation
 
 ENV APP_DIR=/srv/app
-ENV GIT_BRANCH 0.0.17
+ENV GIT_BRANCH 0.0.18
 ENV GIT_URL https://github.com/ckan/datapusher.git
 ENV JOB_CONFIG ${APP_DIR}/datapusher_settings.py
 


### PR DESCRIPTION
Minor update of Datapusher from 0.0.17 to 0.0.18. The version 0.0.17 is failing to build, failing at the cryptography dependency:

```
cecivieira@cecivieira-Inspiron-7380:~/Projetos/docker-ckan$ docker-compose build
solr uses an image, skipping
redis uses an image, skipping
Building datapusher
Step 1/13 : FROM alpine:3.13
3.13: Pulling from library/alpine
72cfd02ff4d0: Pull complete
Digest: sha256:100448e45467d4f3838fc8d95faab2965e22711b6edf67bbd8ec9c07f612b553
Status: Downloaded newer image for alpine:3.13
 ---> 6b5c5e00213a
Step 2/13 : MAINTAINER Open Knowledge Foundation
 ---> Running in 8244d80caf3b
Removing intermediate container 8244d80caf3b
 ---> 41d69b0a46b3
Step 3/13 : ENV APP_DIR=/srv/app
 ---> Running in 9ba5a72c2403
Removing intermediate container 9ba5a72c2403
 ---> 1ec74b69b6da
Step 4/13 : ENV GIT_BRANCH 0.0.17
 ---> Running in 8a174ae715cc
Removing intermediate container 8a174ae715cc
 ---> 045fe479325d
Step 5/13 : ENV GIT_URL https://github.com/ckan/datapusher.git
 ---> Running in f9582c6f32b5
Removing intermediate container f9582c6f32b5
 ---> d18ff23fbd33
Step 6/13 : ENV JOB_CONFIG ${APP_DIR}/datapusher_settings.py
 ---> Running in ddf4836463b2
Removing intermediate container ddf4836463b2
 ---> 031342e36e5f
Step 7/13 : WORKDIR ${APP_DIR}
 ---> Running in 176afc3ebdb2
Removing intermediate container 176afc3ebdb2
 ---> 628679b0f13b
Step 8/13 : RUN apk add --no-cache     python3     py3-pip     py3-wheel     libffi-dev     libressl-dev     libxslt     uwsgi     uwsgi-http     uwsgi-corerouter     uwsgi-python     && apk add --no-cache --virtual .build-deps     gcc     git     musl-dev     python3-dev     libxml2-dev     libxslt-dev     libmagic     openssl-dev     cargo
 ---> Running in 3825a9afb3a1
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/55) Installing linux-headers (5.7.8-r0)
(2/55) Installing libffi (3.3-r2)
(3/55) Installing pkgconf (1.7.3-r0)
(4/55) Installing libffi-dev (3.3-r2)
(5/55) Installing libressl3.1-libcrypto (3.1.5-r0)
(6/55) Installing libressl3.1-libssl (3.1.5-r0)
(7/55) Installing libressl3.1-libtls (3.1.5-r0)
(8/55) Installing libressl-dev (3.1.5-r0)
(9/55) Installing libgpg-error (1.41-r0)
(10/55) Installing libgcrypt (1.8.8-r1)
(11/55) Installing xz-libs (5.2.5-r1)
(12/55) Installing libxml2 (2.9.14-r1)
(13/55) Installing libxslt (1.1.35-r0)
(14/55) Installing libbz2 (1.0.8-r1)
(15/55) Installing expat (2.2.10-r6)
(16/55) Installing gdbm (1.19-r0)
(17/55) Installing ncurses-terminfo-base (6.2_p20210109-r1)
(18/55) Installing ncurses-libs (6.2_p20210109-r1)
(19/55) Installing readline (8.1.0-r0)
(20/55) Installing sqlite-libs (3.34.1-r0)
(21/55) Installing python3 (3.8.10-r0)
(22/55) Installing py3-appdirs (1.4.4-r1)
(23/55) Installing py3-ordered-set (4.0.2-r0)
(24/55) Installing py3-parsing (2.4.7-r1)
(25/55) Installing py3-six (1.15.0-r0)
(26/55) Installing py3-packaging (20.9-r0)
(27/55) Installing py3-setuptools (51.3.3-r0)
(28/55) Installing py3-chardet (4.0.0-r0)
(29/55) Installing py3-idna (3.1-r0)
(30/55) Installing py3-urllib3 (1.26.2-r1)
(31/55) Installing py3-requests (2.25.1-r1)
(32/55) Installing py3-msgpack (1.0.2-r0)
(33/55) Installing py3-lockfile (0.12.2-r3)
(34/55) Installing py3-cachecontrol (0.12.6-r0)
(35/55) Installing py3-colorama (0.4.4-r0)
(36/55) Installing py3-contextlib2 (0.6.0-r0)
(37/55) Installing py3-distlib (0.3.1-r1)
(38/55) Installing py3-distro (1.5.0-r1)
(39/55) Installing py3-webencodings (0.5.1-r3)
(40/55) Installing py3-html5lib (1.1-r0)
(41/55) Installing py3-pytoml (0.1.21-r0)
(42/55) Installing py3-pep517 (0.9.1-r0)
(43/55) Installing py3-progress (1.5-r0)
(44/55) Installing py3-retrying (1.3.3-r0)
(45/55) Installing py3-toml (0.10.2-r0)
(46/55) Installing py3-pip (20.3.4-r0)
(47/55) Installing py3-wheel (0.36.2-r0)
(48/55) Installing mailcap (2.1.49-r0)
(49/55) Installing libcap (2.46-r0)
(50/55) Installing jansson (2.13.1-r0)
(51/55) Installing pcre (8.44-r0)
(52/55) Installing uwsgi (2.0.19.1-r1)
Executing uwsgi-2.0.19.1-r1.pre-install
(53/55) Installing uwsgi-corerouter (2.0.19.1-r1)
(54/55) Installing uwsgi-http (2.0.19.1-r1)
(55/55) Installing uwsgi-python3 (2.0.19.1-r1)
Executing busybox-1.32.1-r9.trigger
OK: 105 MiB in 69 packages
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.13/community/x86_64/APKINDEX.tar.gz
(1/33) Installing libgcc (10.2.1_pre1-r3)
(2/33) Installing libstdc++ (10.2.1_pre1-r3)
(3/33) Installing binutils (2.35.2-r1)
(4/33) Installing libgomp (10.2.1_pre1-r3)
(5/33) Installing libatomic (10.2.1_pre1-r3)
(6/33) Installing libgphobos (10.2.1_pre1-r3)
(7/33) Installing gmp (6.2.1-r1)
(8/33) Installing isl22 (0.22-r0)
(9/33) Installing mpfr4 (4.1.0-r0)
(10/33) Installing mpc1 (1.2.0-r0)
(11/33) Installing gcc (10.2.1_pre1-r3)
(12/33) Installing ca-certificates (20220614-r0)
(13/33) Installing brotli-libs (1.0.9-r3)
(14/33) Installing nghttp2-libs (1.42.0-r1)
(15/33) Installing libcurl (7.79.1-r3)
(16/33) Installing pcre2 (10.36-r1)
(17/33) Installing git (2.30.5-r0)
(18/33) Installing musl-dev (1.2.2-r1)
(19/33) Installing python3-dev (3.8.10-r0)
(20/33) Installing zlib-dev (1.2.12-r3)
(21/33) Installing xz-dev (5.2.5-r1)
(22/33) Installing libxml2-dev (2.9.14-r1)
(23/33) Installing libxslt-dev (1.1.35-r0)
(24/33) Installing libmagic (5.39-r0)
(25/33) Installing openssl-dev (1.1.1q-r0)
(26/33) Installing rust-stdlib (1.47.0-r2)
(27/33) Installing llvm10-libs (10.0.1-r1)
(28/33) Installing rust (1.47.0-r2)
(29/33) Installing http-parser (2.9.4-r0)
(30/33) Installing libssh2 (1.9.0-r1)
(31/33) Installing libgit2 (1.1.0-r1)
(32/33) Installing cargo (1.47.0-r2)
(33/33) Installing .build-deps (20220919.232239)
Executing busybox-1.32.1-r9.trigger
Executing ca-certificates-20220614-r0.trigger
OK: 554 MiB in 102 packages
Removing intermediate container 3825a9afb3a1
 ---> ef9ec4479204
Step 9/13 : RUN mkdir ${APP_DIR}/src && cd ${APP_DIR}/src &&     git clone -b ${GIT_BRANCH} --depth=1 --single-branch ${GIT_URL} &&     cd datapusher &&     python3 setup.py install &&     pip3 install --no-cache-dir -r requirements.txt
 ---> Running in f807ceab58e5
Cloning into 'datapusher'...
Note: switching to '3241679453f493153219850582196d9a5535e32f'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

running install
running bdist_egg
running egg_info
creating datapusher.egg-info
writing datapusher.egg-info/PKG-INFO
writing dependency_links to datapusher.egg-info/dependency_links.txt
writing entry points to datapusher.egg-info/entry_points.txt
writing top-level names to datapusher.egg-info/top_level.txt
writing manifest file 'datapusher.egg-info/SOURCES.txt'
reading manifest file 'datapusher.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'datapusher.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
creating build
creating build/lib
creating build/lib/datapusher
copying datapusher/jobs.py -> build/lib/datapusher
copying datapusher/main.py -> build/lib/datapusher
copying datapusher/__init__.py -> build/lib/datapusher
creating build/bdist.linux-x86_64
creating build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/datapusher
copying build/lib/datapusher/jobs.py -> build/bdist.linux-x86_64/egg/datapusher
copying build/lib/datapusher/main.py -> build/bdist.linux-x86_64/egg/datapusher
copying build/lib/datapusher/__init__.py -> build/bdist.linux-x86_64/egg/datapusher
byte-compiling build/bdist.linux-x86_64/egg/datapusher/jobs.py to jobs.cpython-38.pyc
byte-compiling build/bdist.linux-x86_64/egg/datapusher/main.py to main.cpython-38.pyc
byte-compiling build/bdist.linux-x86_64/egg/datapusher/__init__.py to __init__.cpython-38.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying datapusher.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying datapusher.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying datapusher.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying datapusher.egg-info/entry_points.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying datapusher.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating dist
creating 'dist/datapusher-0.0.17-py3.8.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing datapusher-0.0.17-py3.8.egg
Copying datapusher-0.0.17-py3.8.egg to /usr/lib/python3.8/site-packages
Adding datapusher 0.0.17 to easy-install.pth file
Installing datapusher script to /usr/bin

Installed /usr/lib/python3.8/site-packages/datapusher-0.0.17-py3.8.egg
Processing dependencies for datapusher==0.0.17
Finished processing dependencies for datapusher==0.0.17
Collecting argparse
  Downloading argparse-1.4.0-py2.py3-none-any.whl (23 kB)
Collecting ckanserviceprovider==0.0.10
  Downloading ckanserviceprovider-0.0.10.tar.gz (15 kB)
Collecting html5lib==1.0.1
  Downloading html5lib-1.0.1-py2.py3-none-any.whl (117 kB)
Collecting messytables==0.15.2
  Downloading messytables-0.15.2.tar.gz (30 kB)
Collecting certifi
  Downloading certifi-2022.9.14-py3-none-any.whl (162 kB)
Collecting requests[security]==2.24.0
  Downloading requests-2.24.0-py2.py3-none-any.whl (61 kB)
Collecting APScheduler<3.0.0,>=2.1.2
  Downloading APScheduler-2.1.2-py2.py3-none-any.whl (27 kB)
Collecting Flask>=1.1.1
  Downloading Flask-2.2.2-py3-none-any.whl (101 kB)
Collecting SQLAlchemy<1.4.0,>=1.3.15
  Downloading SQLAlchemy-1.3.24.tar.gz (6.4 MB)
Requirement already satisfied: requests>=2.23.0 in /usr/lib/python3.8/site-packages (from ckanserviceprovider==0.0.10->-r requirements.txt (line 2)) (2.25.1)
Collecting flask-login<0.6.0,>=0.5.0
  Downloading Flask_Login-0.5.0-py2.py3-none-any.whl (16 kB)
Collecting Werkzeug>=1.0.0
  Downloading Werkzeug-2.2.2-py3-none-any.whl (232 kB)
Requirement already satisfied: six>=1.9 in /usr/lib/python3.8/site-packages (from html5lib==1.0.1->-r requirements.txt (line 3)) (1.15.0)
Requirement already satisfied: webencodings in /usr/lib/python3.8/site-packages (from html5lib==1.0.1->-r requirements.txt (line 3)) (0.5.1)
Collecting xlrd>=0.8.0
  Downloading xlrd-2.0.1-py2.py3-none-any.whl (96 kB)
Collecting python-magic>=0.4.12
  Downloading python_magic-0.4.27-py2.py3-none-any.whl (13 kB)
Requirement already satisfied: chardet>=2.3.0 in /usr/lib/python3.8/site-packages (from messytables==0.15.2->-r requirements.txt (line 4)) (4.0.0)
Collecting python-dateutil>=1.5.0
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Collecting lxml>=3.2
  Downloading lxml-4.9.1.tar.gz (3.4 MB)
Collecting json-table-schema<=0.2.1,>=0.2
  Downloading json-table-schema-0.2.1.tar.gz (2.1 kB)
Collecting idna<3,>=2.5
  Downloading idna-2.10-py2.py3-none-any.whl (58 kB)
Collecting urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1
  Downloading urllib3-1.25.11-py2.py3-none-any.whl (127 kB)
Collecting chardet>=2.3.0
  Downloading chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting pyOpenSSL>=0.14
  Downloading pyOpenSSL-22.0.0-py2.py3-none-any.whl (55 kB)
Collecting cryptography>=1.3.4
  Downloading cryptography-38.0.1.tar.gz (599 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Collecting cffi>=1.12
  Downloading cffi-1.15.1.tar.gz (508 kB)
Collecting pycparser
  Downloading pycparser-2.21-py2.py3-none-any.whl (118 kB)
Collecting itsdangerous>=2.0
  Downloading itsdangerous-2.1.2-py3-none-any.whl (15 kB)
Collecting importlib-metadata>=3.6.0
  Downloading importlib_metadata-4.12.0-py3-none-any.whl (21 kB)
Collecting click>=8.0
  Downloading click-8.1.3-py3-none-any.whl (96 kB)
Collecting Jinja2>=3.0
  Downloading Jinja2-3.1.2-py3-none-any.whl (133 kB)
Collecting zipp>=0.5
  Downloading zipp-3.8.1-py3-none-any.whl (5.6 kB)
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-2.1.1.tar.gz (18 kB)
Building wheels for collected packages: ckanserviceprovider, messytables, cryptography, cffi, json-table-schema, lxml, MarkupSafe, SQLAlchemy
  Building wheel for ckanserviceprovider (setup.py): started
  Building wheel for ckanserviceprovider (setup.py): finished with status 'done'
  Created wheel for ckanserviceprovider: filename=ckanserviceprovider-0.0.10-py3-none-any.whl size=17425 sha256=33ddd39ab4c7fffa1d4bb1e40c1f73126360082fedd613845544f984d73a0fe0
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/a9/1e/bb/bb3765c1c38abc6323cc6a60c3adff69ef52e285bb254a5467
  Building wheel for messytables (setup.py): started
  Building wheel for messytables (setup.py): finished with status 'done'
  Created wheel for messytables: filename=messytables-0.15.2-py3-none-any.whl size=28406 sha256=645bdb8790999d07875c63912564b2c4658cdab1fca1f5b3054da951d705f86f
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/30/e3/46/276ca31e318a3139587df8626b60e0058a9a684d1eeafd6dca
  Building wheel for cryptography (PEP 517): started
  Building wheel for cryptography (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /usr/bin/python3 /usr/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py build_wheel /tmp/tmpncbbzr40
       cwd: /tmp/pip-install-mwy628hb/cryptography_289641a4548c42098e25489cc78e0457
  Complete output (179 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-cpython-38
  creating build/lib.linux-x86_64-cpython-38/cryptography
  copying src/cryptography/exceptions.py -> build/lib.linux-x86_64-cpython-38/cryptography
  copying src/cryptography/__about__.py -> build/lib.linux-x86_64-cpython-38/cryptography
  copying src/cryptography/utils.py -> build/lib.linux-x86_64-cpython-38/cryptography
  copying src/cryptography/fernet.py -> build/lib.linux-x86_64-cpython-38/cryptography
  copying src/cryptography/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat
  copying src/cryptography/hazmat/_oid.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat
  copying src/cryptography/hazmat/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat
  creating build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/oid.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/extensions.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/certificate_transparency.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/base.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/ocsp.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/general_name.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/name.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  copying src/cryptography/x509/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/x509
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings
  copying src/cryptography/hazmat/bindings/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends
  copying src/cryptography/hazmat/backends/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/poly1305.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/keywrap.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hashes.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_cipheralgorithm.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/constant_time.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/padding.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/cmac.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_asymmetric.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/hmac.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/_serialization.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  copying src/cryptography/hazmat/primitives/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/_conditional.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/binding.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/openssl
  copying src/cryptography/hazmat/bindings/openssl/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/openssl
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/aead.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x509.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ec.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/poly1305.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ciphers.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dsa.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/rsa.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hashes.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed448.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x448.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/x25519.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/utils.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/cmac.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/dh.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/ed25519.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/hmac.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/backend.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/decode_asn1.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  copying src/cryptography/hazmat/backends/openssl/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/backends/openssl
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/ssh.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs7.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/base.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/pkcs12.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/serialization
  copying src/cryptography/hazmat/primitives/serialization/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/serialization
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/aead.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/algorithms.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/base.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/modes.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/ciphers
  copying src/cryptography/hazmat/primitives/ciphers/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/ciphers
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/pbkdf2.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/scrypt.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/kbkdf.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/x963kdf.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/concatkdf.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/hkdf.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  copying src/cryptography/hazmat/primitives/kdf/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/kdf
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/totp.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/hotp.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/twofactor
  copying src/cryptography/hazmat/primitives/twofactor/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/twofactor
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ec.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dsa.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/rsa.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed448.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x448.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/padding.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/x25519.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/types.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/utils.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/dh.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/ed25519.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  copying src/cryptography/hazmat/primitives/asymmetric/__init__.py -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/primitives/asymmetric
  running egg_info
  writing src/cryptography.egg-info/PKG-INFO
  writing dependency_links to src/cryptography.egg-info/dependency_links.txt
  writing requirements to src/cryptography.egg-info/requires.txt
  writing top-level names to src/cryptography.egg-info/top_level.txt
  reading manifest file 'src/cryptography.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  no previously-included directories found matching 'docs/_build'
  warning: no previously-included files found matching 'vectors'
  warning: no previously-included files matching '*' found under directory 'vectors'
  warning: no previously-included files matching '*' found under directory '.github'
  warning: no previously-included files found matching 'release.py'
  warning: no previously-included files found matching '.readthedocs.yml'
  warning: no previously-included files found matching 'dev-requirements.txt'
  warning: no previously-included files found matching 'tox.ini'
  warning: no previously-included files found matching 'mypy.ini'
  warning: no previously-included files matching '*' found under directory '.circleci'
  adding license file 'LICENSE'
  adding license file 'LICENSE.APACHE'
  adding license file 'LICENSE.BSD'
  adding license file 'LICENSE.PSF'
  writing manifest file 'src/cryptography.egg-info/SOURCES.txt'
  copying src/cryptography/py.typed -> build/lib.linux-x86_64-cpython-38/cryptography
  copying src/cryptography/hazmat/bindings/_openssl.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings
  creating build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/__init__.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/asn1.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/ocsp.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
  copying src/cryptography/hazmat/bindings/_rust/x509.pyi -> build/lib.linux-x86_64-cpython-38/cryptography/hazmat/bindings/_rust
  running build_ext
  running build_rust
  /tmp/pip-build-env-p9kdx3d9/overlay/lib/python3.8/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'cryptography.hazmat.bindings._rust' as data is deprecated, please list it in `packages`.
      !!
 
 
      ############################
      # Package would be ignored #
      ############################
      Python recognizes 'cryptography.hazmat.bindings._rust' as an importable package,
      but it is not listed in the `packages` configuration of setuptools.
 
      'cryptography.hazmat.bindings._rust' has been automatically added to the distribution only
      because it may contain data files, but this behavior is likely to change
      in future versions of setuptools (and therefore is considered deprecated).
 
      Please make sure that 'cryptography.hazmat.bindings._rust' is included as a package by using
      the `packages` configuration field or the proper discovery methods
      (for example by using `find_namespace_packages(...)`/`find_namespace:`
      instead of `find_packages(...)`/`find:`).
 
      You can read more about "package discovery" and "data files" on setuptools
      documentation page.
 
 
  !!
 
    check.warn(importable)
 
      =============================DEBUG ASSISTANCE=============================
      If you are seeing a compilation error please try the following steps to
      successfully install cryptography:
      1) Upgrade to the latest pip and try again. This will fix errors for most
         users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
      2) Read https://cryptography.io/en/latest/installation/ for specific
         instructions for your platform.
      3) Check our frequently asked questions for more information:
         https://cryptography.io/en/latest/faq/
      4) Ensure you have a recent Rust toolchain installed:
         https://cryptography.io/en/latest/installation/#rust
 
      Python: 3.8.10
      platform: Linux-5.13.0-52-generic-x86_64-with
      pip: n/a
      setuptools: 65.3.0
      setuptools_rust: 1.5.2
      rustc: 1.47.0
      =============================DEBUG ASSISTANCE=============================
 
  error: Rust 1.47.0 does not match extension requirement >=1.48.0
  ----------------------------------------
  ERROR: Failed building wheel for cryptography
  Building wheel for cffi (setup.py): started
  Building wheel for cffi (setup.py): finished with status 'done'
  Created wheel for cffi: filename=cffi-1.15.1-cp38-cp38-linux_x86_64.whl size=418789 sha256=c80b6b5f5f00e5505d5d71aafd8fa14fa9971e76f3ef76dd7fd6bcf2e64c59c4
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/4f/6c/1c/87e97bb9c55afbf66881d37eed21c108b012c29105af6be450
  Building wheel for json-table-schema (setup.py): started
  Building wheel for json-table-schema (setup.py): finished with status 'done'
  Created wheel for json-table-schema: filename=json_table_schema-0.2.1-py3-none-any.whl size=2591 sha256=366a551f5ec6fe42116de156e7760153bbcfb706e1a128019c5cdb050265e69e
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/d9/e6/16/b3856c1ab37827779514bdfaf97b28b27bbf0c2c2fd6cc87b3
  Building wheel for lxml (setup.py): started
  Building wheel for lxml (setup.py): still running...
  Building wheel for lxml (setup.py): still running...
  Building wheel for lxml (setup.py): finished with status 'done'
  Created wheel for lxml: filename=lxml-4.9.1-cp38-cp38-linux_x86_64.whl size=8553994 sha256=833ae2b2a0ef4167b14e375e088157da36ea699e26d7e690daf78e8bd4551173
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/03/02/29/e73e6bd0b04b9ddb5e40fe507107c1e6e148bf8521a1964685
  Building wheel for MarkupSafe (setup.py): started
  Building wheel for MarkupSafe (setup.py): finished with status 'done'
  Created wheel for MarkupSafe: filename=MarkupSafe-2.1.1-cp38-cp38-linux_x86_64.whl size=25003 sha256=3d7388509c5c0069dd5e0d183b8861bc89263cd35b7f4a029042e31ec7319f56
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/1e/4f/44/880eea76caa456b86230bdca1a0903ccf0382cd780bdae90d0
  Building wheel for SQLAlchemy (setup.py): started
  Building wheel for SQLAlchemy (setup.py): finished with status 'done'
  Created wheel for SQLAlchemy: filename=SQLAlchemy-1.3.24-cp38-cp38-linux_x86_64.whl size=1253853 sha256=c0df4b63e2c0c15a26b5ffc0c436fa858747bf73c8628429758f374ff3b0c497
  Stored in directory: /tmp/pip-ephem-wheel-cache-ob3s7hor/wheels/24/d2/fe/b05f62703bf7a666e348fe46c74a232c2cc8fbbe427f625f3b
Successfully built ckanserviceprovider messytables cffi json-table-schema lxml MarkupSafe SQLAlchemy
Failed to build cryptography
ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
ERROR: Service 'datapusher' failed to build: The command '/bin/sh -c mkdir ${APP_DIR}/src && cd ${APP_DIR}/src &&     git clone -b ${GIT_BRANCH} --depth=1 --single-branch ${GIT_URL} &&     cd datapusher &&     python3 setup.py install &&     pip3 install --no-cache-dir -r requirements.txt' returned a non-zero code: 1
```
