### PR TITLE
Add mailcap to python2 docker images

### DIFF
--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -24,6 +24,7 @@ RUN apk add --no-cache tzdata \
         apache2-utils \
         libxml2 \
         libxslt \
+        mailcap \
         musl-dev \
         libmagic \
         curl \

--- a/ckan-base/2.9/Dockerfile.py2
+++ b/ckan-base/2.9/Dockerfile.py2
@@ -26,6 +26,7 @@ RUN apk add --no-cache tzdata \
         python2 \
         libxml2 \
         libxslt \
+        mailcap \
         musl-dev \
         libmagic \
         curl \


### PR DESCRIPTION
Package `mailcap` provides `/etc/mime.types` required by the mimetypes module. The python3 images already include it via `uwsgi`.