### PR TITLE
Allow required params for token creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,15 @@ CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 
+# If the "expire_api_token" plugin is enabled we need to define
+# "expires_in" and "unit" parameters
+DATAPUSHER_TOKEN_EXPIRES_IN=
+DATAPUSHER_TOKEN_EXPIRES_UNIT=
+# example for 1 year
+# DATAPUSHER_TOKEN_EXPIRES_IN=365
+# unit=1:Second;unit=2:Minute;unit=3:Hour;unit=4:Day
+# DATAPUSHER_TOKEN_EXPIRES_UNIT=4
+
 TEST_CKAN_SOLR_URL=http://solr:8983/solr/ckan
 TEST_CKAN_REDIS_URL=redis://redis:6379/1
 

--- a/ckan-base/2.10/Dockerfile
+++ b/ckan-base/2.10/Dockerfile
@@ -17,8 +17,8 @@ ENV CKAN__PLUGINS image_view text_view recline_view datastore datapusher envvars
 ENV UWSGI_HARAKIRI=50
 
 # optional. If the "expire_api_token" is enabled you will need this.
-# ENV DATAPUSHER_TOKEN_EXPIRES_IN=365
-# ENV DATAPUSHER_TOKEN_EXPIRES_UNIT=4
+ENV DATAPUSHER_TOKEN_EXPIRES_IN=
+ENV DATAPUSHER_TOKEN_EXPIRES_UNIT=
 
 WORKDIR ${APP_DIR}
 

--- a/ckan-base/2.10/Dockerfile
+++ b/ckan-base/2.10/Dockerfile
@@ -16,6 +16,10 @@ ENV CKAN__PLUGINS image_view text_view recline_view datastore datapusher envvars
 # UWSGI options
 ENV UWSGI_HARAKIRI=50
 
+# optional. If the "expire_api_token" is enabled you will need this.
+# ENV DATAPUSHER_TOKEN_EXPIRES_IN=365
+# ENV DATAPUSHER_TOKEN_EXPIRES_UNIT=4
+
 WORKDIR ${APP_DIR}
 
 # Install necessary packages to run CKAN

--- a/ckan-base/2.10/setup/start_ckan.sh
+++ b/ckan-base/2.10/setup/start_ckan.sh
@@ -27,14 +27,14 @@ sudo -u ckan -EH python3 prerun.py
 # variables.
 if [[ -n "$DATAPUSHER_TOKEN_EXPIRES_IN" ]]
 then
-    EXTRAS="expires_in=$DATAPUSHER_TOKEN_EXPIRES_IN unit=$DATAPUSHER_TOKEN_EXPIRES_UNIT"
+    TOKEN_EXTRAS="expires_in=$DATAPUSHER_TOKEN_EXPIRES_IN unit=$DATAPUSHER_TOKEN_EXPIRES_UNIT"
 else
-    EXTRAS=""
+    TOKEN_EXTRAS=""
 fi
 
 expires_in=30 unit=4
 echo "Set up ckan.datapusher.api_token"
-ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher $EXTRAS | tail -n 1 | tr -d '\t')"
+ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher $TOKEN_EXTRAS | tail -n 1 | tr -d '\t')"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]

--- a/ckan-base/2.10/setup/start_ckan.sh
+++ b/ckan-base/2.10/setup/start_ckan.sh
@@ -20,8 +20,21 @@ fi
 sudo -u ckan -EH python3 prerun.py
 
 # Set a proper value for ckan.datapusher.api_token now that that an admin user exists
+
+# If the expire_api_token plugin is enabled you will need to define
+# "expires_in" and "unit" parameters. If required, add
+# DATAPUSHER_TOKEN_EXPIRES_IN and DATAPUSHER_TOKEN_EXPIRES_UNIT as env
+# variables.
+if [[ -n "$DATAPUSHER_TOKEN_EXPIRES_IN" ]]
+then
+    EXTRAS="expires_in=$DATAPUSHER_TOKEN_EXPIRES_IN unit=$DATAPUSHER_TOKEN_EXPIRES_UNIT"
+else
+    EXTRAS=""
+fi
+
+expires_in=30 unit=4
 echo "Set up ckan.datapusher.api_token"
-ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
+ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher $EXTRAS | tail -n 1 | tr -d '\t')"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]


### PR DESCRIPTION
If the `expire_api_token` plugin is enabled we need to define `expires_in` and `unit` parameters

The environment variables `DATAPUSHER_TOKEN_EXPIRES_IN` and `DATAPUSHER_TOKEN_EXPIRES_UNIT` are proposed to fix a build error

<pre>
 Traceback (most recent call last):
ckan-dev4      |   File "/usr/bin/ckan", line 8, in <module>
ckan-dev4      |     sys.exit(ckan())
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
ckan-dev4      |     return self.main(*args, **kwargs)
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
ckan-dev4      |     rv = self.invoke(ctx)
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
ckan-dev4      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
ckan-dev4      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
ckan-dev4      |     return _process_result(sub_ctx.command.invoke(sub_ctx))
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
ckan-dev4      |     return ctx.invoke(self.callback, **ctx.params)
ckan-dev4      |   File "/usr/lib/python3.10/site-packages/click/core.py", line 760, in invoke
ckan-dev4      |     return __callback(*args, **kwargs)
ckan-dev4      |   File "/srv/app/src/ckan/ckan/cli/user.py", line 200, in add_token
ckan-dev4      |     token = logic.get_action(u"api_token_create")(
ckan-dev4      |   File "/srv/app/src/ckan/ckan/logic/__init__.py", line 551, in wrapped
ckan-dev4      |     result = _action(context, data_dict, **kw)
ckan-dev4      |   File "/srv/app/src/ckan/ckan/logic/action/create.py", line 1524, in api_token_create
ckan-dev4      |     raise ValidationError(errors)
<b>ckan-dev4      | ckan.logic.ValidationError: None - {'expires_in': ['Missing value'], 'unit': ['Missing value']}</b>
postgresql4    | 2023-06-27 18:21:02.796 UTC [65] LOG:  unexpected EOF on client connection with an open transaction
ckan-dev4      | /srv/app/start_ckan_development.sh: Running init file /docker-entrypoint.d/01_lower_ckan_log_level.sh
</pre>