### PR TITLE
Api token expire for ckan 10 dev

### DIFF
--- a/ckan-base/2.10/setup/start_ckan.sh
+++ b/ckan-base/2.10/setup/start_ckan.sh
@@ -32,7 +32,6 @@ else
     TOKEN_EXTRAS=""
 fi
 
-expires_in=30 unit=4
 echo "Set up ckan.datapusher.api_token"
 ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher $TOKEN_EXTRAS | tail -n 1 | tr -d '\t')"
 

--- a/ckan-dev/2.10/setup/start_ckan_development.sh
+++ b/ckan-dev/2.10/setup/start_ckan_development.sh
@@ -47,7 +47,7 @@ ckan config-tool $CKAN_INI -s DEFAULT "debug = true"
 
 # Put a placeholder value for ckan.datapusher.api_token to be able to run commands,
 # will be updated later
-ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx
+ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx expires_in=365 unit=4
 
 # Set up the Secret key used by Beaker and Flask
 # This can be overriden using a CKAN___BEAKER__SESSION__SECRET env var
@@ -78,7 +78,7 @@ sudo -u ckan -EH python3 prerun.py
 
 # Set a proper value for ckan.datapusher.api_token now that that an admin user exists
 echo "Set up ckan.datapusher.api_token"
-ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher | tail -n 1 | tr -d '\t')"
+ckan config-tool $CKAN_INI "ckan.datapusher.api_token=$(ckan -c $CKAN_INI user token add ckan_admin datapusher expires_in=365 unit=4 | tail -n 1 | tr -d '\t')"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]

--- a/ckan-dev/2.10/setup/start_ckan_development.sh
+++ b/ckan-dev/2.10/setup/start_ckan_development.sh
@@ -47,7 +47,7 @@ ckan config-tool $CKAN_INI -s DEFAULT "debug = true"
 
 # Put a placeholder value for ckan.datapusher.api_token to be able to run commands,
 # will be updated later
-ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx expires_in=365 unit=4
+ckan config-tool $CKAN_INI ckan.datapusher.api_token=xxx
 
 # Set up the Secret key used by Beaker and Flask
 # This can be overriden using a CKAN___BEAKER__SESSION__SECRET env var


### PR DESCRIPTION
Fixes error `ckan.logic.ValidationError: None - {'expires_in': ['Missing value'], 'unit': ['Missing value']}`