### PR TITLE
Continue builds if any version fails

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
If CKAN 2.8 fails to build, CKAN 2.9 will not continue.
We need to continue.